### PR TITLE
Add .strip_heredoc to message

### DIFF
--- a/lib/iceboxer/icebox.rb
+++ b/lib/iceboxer/icebox.rb
@@ -48,7 +48,7 @@ module Iceboxer
     end
 
     def message(reason)
-      <<-MSG
+      <<-MSG.strip_heredoc
       ![picture of the iceboxer](https://cloud.githubusercontent.com/assets/699550/5107249/0585a470-6fce-11e4-8190-4413c730e8d8.png)
 
       #{reason[:message]}


### PR DESCRIPTION
Otherwise the message will include spaces in the begining and GitHub will post them as a code block.
See https://github.com/Shopify/shopify/pull/24566#issuecomment-72315948 for example